### PR TITLE
fix: 라우트 경로 에러

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,7 +7,7 @@ import Home from './pages/Home';
 const App = () => {
   return (
     <div className='container'>
-      <Router>
+      <Router basename={process.env.PUBLIC_URL}>
         <Routes>
           <Route path='/' element={<Home/>} />
           <Route path='/blog/:id' element={<Blog/>} />


### PR DESCRIPTION
기본 경로를 지정하지 않아 github.io/blog 접속 시 빈 페이지로 출력되는 문제 수정